### PR TITLE
Removes the restriction of single response type AuthN requests

### DIFF
--- a/openid-deferred-token-response-1_0.md
+++ b/openid-deferred-token-response-1_0.md
@@ -101,7 +101,7 @@ This will define any parameters needed for registration and discovery of the DTR
 
 ## Authorization Server Metadata
 Response type:
-: A `deferred_code` response type is introduced by this specification in order to indicate to the OP that a deferred authentication response is desired once the user interaction ends. Value MUST be provided in the response type attribute and 
+: A `deferred_code` response type is introduced by this specification in order to indicate to the OP that a deferred authentication response is acceptable once the user interaction ends.
 
 Grant type: 
 : This specification introduces the Deferred grant type (an extension grant type as defined by [@!RFC6749, section 4.5]) with the value: `urn:openid:params:grant-type:deferred`


### PR DESCRIPTION
This proposal removes the rule defined previously where the OP couldn't accept multiple values in the response type attribute in authentication requests