### PR TITLE
Clarify usage of deferred notification token.

### DIFF
--- a/openid-deferred-token-response-1_0.md
+++ b/openid-deferred-token-response-1_0.md
@@ -233,7 +233,7 @@ The Client makes an HTTP POST request to the Token Endpoint by sending the follo
 : REQUIRED. The unique identifier to identify the Authentication Request made by the Client. The OP MUST check whether the `deferred_code` was issued to this Client in response to an Authentication Request. Otherwise, an error MUST be returned.
 
 `deferred_notification_token`
-: OPTIONAL. A bearer access token which can be used by the OP to authorize when sending a Ping Callback for this request.
+: OPTIONAL. A bearer access token which the OP can use to access the Client's Deferred Notification Endpoint when sending a Ping Callback for this request.
 
 Supported extension parameters from the OAuth 2.0 Token Request MAY be included in this request.
 


### PR DESCRIPTION
Clarifies that:
1. It is optional to use, and some other form of protection can be used instead.
2. It should be sent to the OP with the code exchange request.
3. Clients SHOULD bind it to the auth_id received after the code exchange.

Closes #58.